### PR TITLE
Fix flashPageWriteIfNeeded if flash already erased

### DIFF
--- a/ARMCM3-STM32F107-BOOTLOADER/flash/flash.c
+++ b/ARMCM3-STM32F107-BOOTLOADER/flash/flash.c
@@ -180,12 +180,13 @@ int flashPageWriteIfNeeded(flashpage_t page, const flashdata_t* buffer){
     return err;
 
   /* Page needs erase */
-  if (err == 2)
+  if (err == 2) {
     err = flashPageErase(page);
 
-  /* Return errors of page erase */
-  if (err != FLASH_RETURN_SUCCESS)
-    return err;
+    /* Return errors of page erase */
+    if (err != FLASH_RETURN_SUCCESS)
+      return err;
+  }
 
   err = flashPageWrite(page, buffer);
 


### PR DESCRIPTION
Hello,

First, thanks for a great example bootloader.

When I was trying to get it to work, I had manually erased the flash on my device - this seemed to cause an issue in the flashPageWriteIfNeeded function as the flashPageCompare responses weren't handled quite correctly, specifically the case where the page was already erased.

A very minor fix is attached. Feel free to do with it what you will. Let me know if I am understanding something incorrectly.

Thanks.
